### PR TITLE
Add Timezone to AppDaemon environment variables

### DIFF
--- a/templates/appdaemon/0/docker-compose.yml
+++ b/templates/appdaemon/0/docker-compose.yml
@@ -11,3 +11,4 @@ services:
       HA_URL: ${HA_URL}
       HA_KEY: ${HA_KEY}
       DASH_URL: ${DASH_URL}
+      TZ: ${TZ}

--- a/templates/appdaemon/0/rancher-compose.yml
+++ b/templates/appdaemon/0/rancher-compose.yml
@@ -29,3 +29,9 @@ version: '2'
      label: 'Home Assistant API key'
      required: false
      type: 'string'
+   - variable: 'TZ'
+     description: 'Timezone (eg. Europe/Amsterdam)'
+     label: 'Timezone'
+     required: true
+     type: 'string'
+     default: 'Europe/Amsterdam'


### PR DESCRIPTION
AppDaemon should be run with the same Timezone setup as Home Assistant, otherwise there might be mismatch in time in between those two.
This is crucial for AppDaemon Scheduler Calls like run_at().